### PR TITLE
fix for "make view"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ wc:	pdf
 #help	view	view the PDF-file
 .PHONY: view
 view: pdf
-	${PDFVIEWER} *_${PROJECTNAME}.pdf
+	${PDFVIEWER} ${DATESTAMP_AND_PROJECT}.pdf
 
 # --------------------------------------------------------
 


### PR DESCRIPTION
Die Form "*_${PROJECTNAME}.pdf" ruft alle bereits vorher erstellten Dateien auf.  Mit "${DATESTAMP_AND_PROJECT}.pdf" wird nur die eben erstellte PDF angezeigt.