### PR TITLE
abstract link in TOC pointing in the wrong section

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -238,6 +238,7 @@
 
 %% include the abstract without chapter number but include it on table of contents:
 \cleardoublepage
+\phantomsection
 \addcontentsline{toc}{chapter}{Abstract}
 \include{abstract}              %% Abstract
 


### PR DESCRIPTION
Hi,
I discovered today that the link to the abstract in the table of contents leads to the statutory declaration (try it for yourself in the attached [file](https://github.com/novoid/LaTeX-KOMA-template/files/872598/2017-03-27_Projectname.pdf)). The solution is to add an anchor for the hyperref package in the abstract section.

Matthias


