### PR TITLE
Add *.out files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ template/auto/*
 *.bbl
 *.blg
 *.log
+*.out
 *.toc
 Template-Documentation.tex
 main.pdf


### PR DESCRIPTION
This template generates `main.out` which I believe can be ignored, as well as .out files in general.

https://tex.stackexchange.com/questions/17845/which-auxiliary-latex-files-should-be-ignored-by-version-control-software