### PR TITLE
Fix warnings

### DIFF
--- a/template/pdf_settings.tex
+++ b/template/pdf_settings.tex
@@ -51,7 +51,6 @@ plainpages=false, % correct, if pdflatex complains: ``destination with same iden
 %% colors: https://secure.wikimedia.org/wikibooks/en/wiki/LaTeX/Colors
 urlcolor=DispositionColor, %%
 linkcolor=DispositionColor, %%
-pagecolor=DispositionColor, %%
 citecolor=DispositionColor, %%
 anchorcolor=DispositionColor, %%
 colorlinks=\mycolorlinks, % turn on/off colored links (on: better for

--- a/template/pdf_settings.tex
+++ b/template/pdf_settings.tex
@@ -41,7 +41,7 @@
 \usepackage[%
 unicode=true, % loads with unicode support
 %a4paper=true, %
-pdftex=true, %
+pdftex, %
 backref, %
 pagebackref=false, % creates backward references too
 bookmarks=true, % generate bookmarks in PDF files

--- a/template/pdf_settings.tex
+++ b/template/pdf_settings.tex
@@ -46,7 +46,7 @@ backref, %
 pagebackref=false, % creates backward references too
 bookmarks=true, % generate bookmarks in PDF files
 bookmarksopen=false, % when starting with AcrobatReader, the Bookmarkcolumn is opened
-pdfpagemode=None,% None, UseOutlines, UseThumbs, FullScreen
+pdfpagemode=UseNone, % UseNone, UseOutlines, UseThumbs, FullScreen
 plainpages=false, % correct, if pdflatex complains: ``destination with same identifier already exists''
 %% colors: https://secure.wikimedia.org/wikibooks/en/wiki/LaTeX/Colors
 urlcolor=DispositionColor, %%

--- a/template/preamble.tex
+++ b/template/preamble.tex
@@ -11,7 +11,7 @@
 %doc% \newcommand{\mylinespread}{1.0}  \newcommand{\mycolorlinks}{true}
 %doc% \documentclass[12pt,paper=a4,parskip=half,DIV=calc,oneside,%%
 %doc% headinclude,footinclude=false,open=right,bibliography=totoc]{scrartcl}
-%doc% \usepackage[utf8]{inputenc}\usepackage[ngerman,american]{babel}\usepackage{scrpage2}
+%doc% \usepackage[utf8]{inputenc}\usepackage[ngerman,american]{babel}\usepackage{scrlayer-scrpage}
 %doc% \usepackage{ifthen}\usepackage{eurosym}\usepackage{xspace}\usepackage[usenames,dvipsnames]{xcolor}
 %doc% \usepackage[protrusion=true,factor=900]{microtype}
 %doc% \usepackage{enumitem}
@@ -417,13 +417,14 @@ BCOR=\myBCOR,        %% binding correction (depends on how you bind
 \usepackage[\mylanguage]{babel}  %% used languages; default language is *last* language of options
 
 %doc%
-%doc% \subsection{\texttt{scrpage2}: Headers and footers}
+%doc% \subsection{\texttt{scrlayer-scrpage}: Headers and footers}
 %doc%
-%doc% Since this template is based on \myacro{KOMA} script it uses its great \texttt{scrpage2}
+%doc% Since this template is based on \myacro{KOMA} script it uses its great
+%doc% \texttt{scrlayer-scrpage} (previously \texttt{scrpage2})
 %doc% package for defining header and footer information. Please refer to the \myacro{KOMA}
 %doc% script documentation how to use this package.
 %doc%
-\usepackage{scrpage2} %%  advanced page style using KOMA
+\usepackage{scrlayer-scrpage} %%  advanced page style using KOMA
 
 
 %doc%

--- a/template/typographic_settings.tex
+++ b/template/typographic_settings.tex
@@ -130,7 +130,7 @@
 %doc% Settings for colored links are handled by the definitions of the
 %doc% \texttt{hyperref} package (see section~\ref{sec:pdf}).
 %doc% 
-\setheadsepline{.4pt}[\color{DispositionColor}]
+\KOMAoption{headsepline}{.4pt}{\color{DispositionColor}}
 \renewcommand{\headfont}{\normalfont\sffamily\color{DispositionColor}}
 \renewcommand{\pnumfont}{\normalfont\sffamily\color{DispositionColor}}
 \addtokomafont{disposition}{\color{DispositionColor}}


### PR DESCRIPTION
For details, see individual commits.

c182c80fec5c1ae7e6e2b1d2ff4df970698d7803 addresses #11 - Debian must have caught up in those 5 years ;)

Also might be worth considering is adding textcomp to the preamble,
since using the default font that comes with the template produces a warning.
It could then be noted in the docstring that it's optional.
However I understand not wanting to include something that may be unnecessary for the user.
It could be seen as bloat, which is why it's not in this PR.