### PR TITLE
Fix: Strange digits in pdf output when using mutated vovels in german or quotations marks

### DIFF
--- a/template/preamble.tex
+++ b/template/preamble.tex
@@ -11,6 +11,7 @@
 %doc% \newcommand{\mylinespread}{1.0}  \newcommand{\mycolorlinks}{true}
 %doc% \documentclass[12pt,paper=a4,parskip=half,DIV=calc,oneside,%%
 %doc% headinclude,footinclude=false,open=right,bibliography=totoc]{scrartcl}
+%doc% \usepackage[T1]{fontenc}\usepackage{lmodern}
 %doc% \usepackage[utf8]{inputenc}\usepackage[ngerman,american]{babel}\usepackage{scrlayer-scrpage}
 %doc% \usepackage{ifthen}\usepackage{eurosym}\usepackage{xspace}\usepackage[usenames,dvipsnames]{xcolor}
 %doc% \usepackage[protrusion=true,factor=900]{microtype}
@@ -388,6 +389,23 @@ BCOR=\myBCOR,        %% binding correction (depends on how you bind
 
 % FIXXME: adopting language:
 % add or modify language parameter of package »babel« and use language switches described in babel-documentation
+
+%doc%
+%doc% \subsection{\texttt{ifthen}: Conditional execution of latex code}
+%doc%
+%doc% This package allows conditional code execution (e.g. changing parameters passed to packages).
+%doc%
+\usepackage{ifthen}
+
+%doc%
+%doc% \subsection{\texttt{fontenc}: Switch to Western European output charset}
+%doc%
+%doc% This allows \LaTeX{} to output special digits like german mutated vovels or quotation marks without assembling them of basic US-ASCII ones. This makes text in the generated pdf copyable. Sadly this also influences the fonts used, as the default ones do not contain most of the characters we use here. The lmodern font set is usually used to counteract this problem.
+%doc%
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+%% Source: https://texwelt.de/fragen/5537/was-macht-eigentlich-usepackaget1fontenc
+%%         https://tex.stackexchange.com/questions/227063/fontenc-changes-sans-serif-bold-font-in-koma-script
 
 %doc%
 %doc% \subsection{\texttt{inputenc}: UTF8 as input charset}

--- a/template/preamble.tex
+++ b/template/preamble.tex
@@ -390,11 +390,10 @@ BCOR=\myBCOR,        %% binding correction (depends on how you bind
 % FIXXME: adopting language:
 % add or modify language parameter of package »babel« and use language switches described in babel-documentation
 
-%doc%
-%doc% \subsection{\texttt{ifthen}: Conditional execution of latex code}
-%doc%
-%doc% This package allows conditional code execution (e.g. changing parameters passed to packages).
-%doc%
+%doc% \item[\texttt{\href{http://ctan.org/pkg/ifthen}{%%
+%doc% ifthen%%
+%doc% }}]
+%doc% For using if/then/else statements for example in macros
 \usepackage{ifthen}
 
 %doc%
@@ -611,13 +610,6 @@ hyperref=true, %% using hyperref-package references
 %doc% }}]
 %doc% For additional special characters available by \verb#\ding{}#
 \usepackage{pifont}
-
-
-%doc% \item[\texttt{\href{http://ctan.org/pkg/ifthen}{%%
-%doc% ifthen%%
-%doc% }}]
-%doc% For using if/then/else statements for example in macros
-\usepackage{ifthen}
 
 %% pre-define ifthen-boolean variables:
 \newboolean{myaddcolophon}


### PR DESCRIPTION
Hi,

i'm currently merging my previous preambles into yours for a master's thesis and want to contribute some things which I think would also be beneficial for other users of your otherwise highly sophisticated template.

Up to now my most important change would be adding the fontenc package. On a tl;dr level this makes mutated vovels and quotation marks copyable from the result pdf into a text editor.
In detail it's probably better if you quickly go through these two links before approving this request, as the impact of this small change is quite big:
[fontenc description](https://texwelt.de/fragen/5537/was-macht-eigentlich-usepackaget1fontenc)
[lmodern description](https://tex.stackexchange.com/questions/227063/fontenc-changes-sans-serif-bold-font-in-koma-script)

I also explicitly included the ifthen package. It looks like this happend somewhere implicitly before your first usage. If the package which does this removes the dependency your preamble is broken.

Other than that I especially like your idea of using make :+1:  :)