### PR TITLE
Implemented a global language switch and translated titlepages

### DIFF
--- a/abstract.tex
+++ b/abstract.tex
@@ -6,7 +6,7 @@
 
 
 This is a placeholder for the abstract. It summarizes the whole thesis
-to give a very short overview. Usually, this the abstract is written
+to give a very short overview. Usually, this abstract is written
 when the whole thesis text is finished.
 
 

--- a/colophon.tex
+++ b/colophon.tex
@@ -8,16 +8,28 @@
 %%      Karl Voit
 
 
+\ifthenelse{\equal{\mylanguage}{english}}%%
+{%%
 \newcommand{\mycolophon}{%%
-  This document 
-  %% was written with \myacro{GNU}~Emacs, 
-  is set in Palatino, compiled with
+  This document is set in Palatino, compiled with
   \href{http://LaTeX.TUGraz.at}{pdf\LaTeX2e} and
   \href{http://en.wikipedia.org/wiki/Biber_(LaTeX)}{\texttt{Biber}}.
 
   The \LaTeX{} template from Karl Voit is based on
   \href{http://www.komascript.de/}{KOMA script} and can be found 
   online: \href{https://github.com/novoid/LaTeX-KOMA-template}{https://github.com/novoid/LaTeX-KOMA-template}
+}
+}
+{%%
+\newcommand{\mycolophon}{%%
+  Dieses Dokument ist in der Schriftart Palatino mit
+  \href{http://LaTeX.TUGraz.at}{pdf\LaTeX2e} und
+  \href{http://en.wikipedia.org/wiki/Biber_(LaTeX)}{\texttt{Biber}} kompiliert.
+
+  Das \LaTeX{} Template von Karl Voit basiert auf
+  \href{http://www.komascript.de/}{KOMA Script} und ist online
+  verfügbar: \href{https://github.com/novoid/LaTeX-KOMA-template}{https://github.com/novoid/LaTeX-KOMA-template}
+}
 }
 
 

--- a/main.tex
+++ b/main.tex
@@ -51,10 +51,8 @@
 %% spacing. Please use with caution: 100% ("1.0") is fine because the
 %% font was designed for it.
 
-\newcommand{\mylanguage}{ngerman,american}
-%% "english,ngerman", "ngerman,english", ...
-%% NOTE: The *last* language is the active one!
-%% See babel documentation for further details.
+\newcommand{\mylanguage}{english}
+%% "english" or "german"
 
 %% BibLaTeX-settings: (see biblatex reference for further description)
 \newcommand{\mybiblatexstyle}{authoryear}
@@ -91,13 +89,13 @@
 \newcommand{\mycolorlinks}{true}  %% "true" or "false"
 %% Enables or disables colored links (hyperref package).
 
-\newcommand{\mytitlepage}{template/title_Thesis_TU_Graz}
+\newcommand{\mytitlepage}{template/title_Thesis_TU_Graz_-_kazemakase}
 %% Your own or one of following pre-defined title pages:
 %% "template/title_plain_maketitle": simple maketitle page
-%% "template/title_Diplomarbeit_KF_Uni_Graz.tex": fancy (german) title page for KF Uni Graz
+%% "template/title_Diplomarbeit_KF_Uni_Graz.tex": fancy title page for KF Uni Graz
 %% "template/title_Thesis_TU_Graz":
 %%             titlepage for Graz University of Technology (correct
-%%             (old?) Corporate Design) by Karl Voit (2012)
+%%             old Corporate Design) by Karl Voit (2012)
 %% "template/title_Thesis_TU_Graz_-_kazemakase":
 %%             titlepage for Graz University of Technology
 %%             (correct new Corporate Design) by kazemakase (2013):
@@ -122,10 +120,6 @@
 %% If set to "true": the current list of open todos is added after the
 %% table of contents. If \mytodonotesoptions is set to "disable", no
 %% list of todos is added, independent of this setting here.
-
-\setboolean{english_affidavit}{true}  %% "true" or "false"
-%% If set to "true": the language of the statutory declaration text is set to
-%% English, otherwise it is in German.
 
 
 %% ========================================================================

--- a/template/declaration_TU_Graz.tex
+++ b/template/declaration_TU_Graz.tex
@@ -20,7 +20,7 @@
 }
 
 
-\ifthenelse{\boolean{english_affidavit}}{
+\ifthenelse{\equal{\mylanguage}{english}}{
   \section*{Affidavit}
   I declare that I have authored this thesis independently, that I have
   not used other than the declared sources/resources, and that I have

--- a/template/preamble.tex
+++ b/template/preamble.tex
@@ -427,8 +427,9 @@ BCOR=\myBCOR,        %% binding correction (depends on how you bind
 %doc%
 %doc% \subsection{\texttt{babel}: Language settings}
 %doc%
-%doc% The default setting of the language is American. Please change settings for
-%doc% additional or alternative languages used in \texttt{main.tex}.
+%doc% The default setting of the english language kind is American. For german, the
+%doc% \texttt{ngerman} kind is used. Please change settings for additional or
+%doc% alternative languages in \texttt{template/preamble.tex}.
 %doc%
 %doc% Please note that the default language of the document is the \emph{last} language
 %doc% which is added to the package options.
@@ -439,7 +440,14 @@ BCOR=\myBCOR,        %% binding correction (depends on how you bind
 %doc% \verb+\foreigntextquote+, or \verb+\foreignblockquote+ provided by
 %doc% \texttt{csquotes} (see Section~\ref{sub:csquotes}).
 %doc%
-\usepackage[\mylanguage]{babel}  %% used languages; default language is *last* language of options
+\ifthenelse{\equal{\mylanguage}{english}}%%
+{%%
+  \usepackage[ngerman,american]{babel}
+}
+{%%
+  \usepackage[american,ngerman]{babel}
+}
+
 
 %doc%
 %doc% \subsection{\texttt{scrlayer-scrpage}: Headers and footers}
@@ -449,7 +457,7 @@ BCOR=\myBCOR,        %% binding correction (depends on how you bind
 %doc% package for defining header and footer information. Please refer to the \myacro{KOMA}
 %doc% script documentation how to use this package.
 %doc%
-\usepackage{scrlayer-scrpage} %%  advanced page style using KOMA
+\usepackage{scrlayer-scrpage}%%  advanced page style using KOMA
 
 
 %doc%

--- a/template/title_Diplomarbeit_KF_Uni_Graz.tex
+++ b/template/title_Diplomarbeit_KF_Uni_Graz.tex
@@ -16,7 +16,29 @@
 {\LARGE\bfseries\myworktitle}
 
 \vfill
+\ifthenelse{\equal{\mylanguage}{english}}%%
+{%%
+to obtain the academic degree\\[5mm]
+{\LARGE\mygrade}\\[5mm]
+in the field of study \mystudy\\
+at the \myuniversity
 
+\vfill
+
+on the topic\\[10mm]
+
+{\LARGE\bfseries\mytitle}
+
+\vfill
+
+submitted to the\\
+\myinstitute
+
+Supervisor: \mysupervisor
+
+from\\[5mm]
+}
+{%%
 zur Erlangung des akademischen Grades eines\\[5mm]
 {\LARGE\mygrade}\\[5mm]
 der Studienrichtung \mystudy\\
@@ -36,6 +58,7 @@ eingereicht am\\
 Begutachter: \mysupervisor
 
 von\\[5mm]
+}
 {\Large\bfseries\myauthor}\\[5mm]
 \myhomestreet\\
 \myhomepostalnumber~\myhometown

--- a/template/title_Thesis_TU_Graz.tex
+++ b/template/title_Thesis_TU_Graz.tex
@@ -34,6 +34,8 @@
 
 {\bfseries\large\myworktitle}
 
+\ifthenelse{\equal{\mylanguage}{english}}%%
+{%%
 to achieve the university degree of
 
 \mygrade
@@ -63,6 +65,38 @@ Supervisor
 
 \myinstitute\\
 Head: \myinstitutehead\\
+}
+{%%
+zur Erlangung des akademischen Grades eines
+
+\mygrade
+
+\mydegreeprogramme
+
+
+\vfill\vfill\vfill
+
+
+an der
+
+\vfill
+
+{\bfseries\large\myuniversity}
+
+
+\vfill\vfill\vfill
+
+
+Begutachter
+
+\mysupervisor
+%usually not mentioned on titlepage:% Evaluator: \myevaluator
+
+\vfill
+
+\myinstitute\\
+Leitung: \myinstitutehead\\
+}
 
 \vfill
 

--- a/template/title_Thesis_TU_Graz_-_kazemakase.tex
+++ b/template/title_Thesis_TU_Graz_-_kazemakase.tex
@@ -43,6 +43,23 @@
 
 {\normalsize\bfseries\myworktitle}\\
 \vfill
+\ifthenelse{\equal{\mylanguage}{english}}%%
+{%%
+to obtain the academic degree\\
+{\mygrade}\\
+\vfill
+submitted at the\\
+{\normalsize\bfseries\myuniversity}
+
+\vfill\vfill\vfill
+\vfill\vfill\vfill
+
+Supervisor\\
+\mysupervisor\\
+\vfill
+Cosupervisor\\
+}
+{%%
 zur Erlangung des akademischen Grades\\
 {\mygrade}\\
 \vfill
@@ -56,6 +73,7 @@ Betreuer\\
 \mysupervisor\\
 \vfill
 Mitbetreuer\\
+}
 \mycosupervisor\\
 %usually not mentioned on titlepage:% Evaluator: \myevaluator
 \vfill

--- a/template/title_VWA.tex
+++ b/template/title_VWA.tex
@@ -18,6 +18,19 @@
 
 \vfill
 
+\ifthenelse{\equal{\mylanguage}{english}}%%
+{%%
+Pre-scientific work written by\\[5mm]
+{\Large\bfseries\myauthor}\\[5mm]
+Class \mystudy\\[50mm]
+
+\vfill
+
+\includegraphics[width=3cm]{figures/institution}\\[5mm]
+
+Supervisor: \mysupervisor
+}
+{%%
 Vorwissenschaftliche Arbeit verfasst von\\[5mm]
 {\Large\bfseries\myauthor}\\[5mm]
 Klasse \mystudy\\[50mm]
@@ -27,6 +40,7 @@ Klasse \mystudy\\[50mm]
 \includegraphics[width=3cm]{figures/institution}\\[5mm]
 
 Betreuer: \mysupervisor
+}
 
 \vfill
 

--- a/template/typographic_settings.tex
+++ b/template/typographic_settings.tex
@@ -169,17 +169,15 @@
 %doc% 
 %doc% \emph{Never} use quotation marks found on your keyboard.
 %doc% They end up in strange characters or false looking quotation marks.
-%doc% 
-%doc% In \LaTeX{} you are able to use typographically correct quotation marks. The package 
+%doc%
+%doc% Different languages also use quotation marks differently. In \LaTeX{} you
+%doc% are able to use typographically correct quotation marks. The package 
 %doc% \href{http://www.ctan.org/pkg/csquotes}{\texttt{csquotes}} offers you with 
 %doc% \verb#\enquote{foobar}# a command to get correct quotation marks around \enquote{foobar}.
-%doc% Please do check the package options in order to modify
-%doc% its settings according to the language used\footnote{most of the time in 
-%doc% combination with the language set in the options of the \texttt{babel} package}.
 %doc% 
 %doc% \href{http://www.ctan.org/pkg/csquotes}{\texttt{csquotes}} is also recommended 
 %doc% by \texttt{biblatex} (see Section~\ref{sec:references}). 
-\usepackage[babel=true,strict=true,english=american,german=guillemets]{csquotes}
+\usepackage[autostyle=true,strict=true,english=american,german=guillemets]{csquotes}
 
 %doc% 
 %doc% \subsection{Line spread}


### PR DESCRIPTION
Hi,

as previously suggested, this is my idea of a global language switch more or less copied from my private preamble.

This could probably ease the life of future users by not having to think about biblatex options and their order unless they have a **specific bilingual use case**. Most of them will just need to write their thesis or whatever in the **one language approved** by their supervisor.

Please also think about the used csquotes option:
`german=guillemets`

The package default would be `quotes` and I also think that quotes are much more popular in german. The last time I had german as a subject in school is already some time ago and even there we only used quotes. The last time I saw guillemets used in german was in some really old books.
[Wikipedia, Anführungszeichen](https://de.wikipedia.org/wiki/Anf%C3%BChrungszeichen#Andere_Sprachen) also seems to suggest quotes as primary default for german. Up to now I did not change that package option yet. I just changed the documentation and replaced the deprecated `babel` option with the now recommended `autostyle`.
